### PR TITLE
Switch to the new Fink API URL

### DIFF
--- a/tools/fink_query_tool.py
+++ b/tools/fink_query_tool.py
@@ -53,7 +53,7 @@ def get_fink_data(objname, verbose=True):
 #   print(f'It is now: {now}')
     # get data for 2016 UU121
     r = requests.post(
-        'https://fink-portal.org/api/v1/sso',
+        'https://api.fink-portal.org/api/v1/sso',
         json={
             'n_or_d': '2016 UU121',
             'withEphem': True,


### PR DESCRIPTION
Hello,

As part of the transition to a new system for Rubin, the URL to access the Fink API has changed:
- old: https://fink-portal.org/api/v1/<endpoint\>
- new: https://api.fink-portal.org/api/v1/<endpoint\>

In this transition period, in case of trouble do not hesitate to check https://fink-broker.readthedocs.io/en/latest/migration